### PR TITLE
Fix: build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,24 @@
+FROM ruby:2.6.8-slim as builder
+
+# For building native extensions
+RUN apt-get update
+RUN apt-get install build-essential -y
+
+# Required bundler version for gems
+ENV BUNDLER_VERSION='2.2.17'
+RUN gem install bundler:${BUNDLER_VERSION}
+
+# Prevent Gemfile to be modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+RUN bundle exec jekyll build
+
 FROM nginx
-COPY ./_site /usr/share/nginx/html
+COPY --from=builder /usr/src/app/_site /usr/share/nginx/html

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,5 @@
 services:
   web:
-    image: nginx
-    volumes:
-     - ./_site:/usr/share/nginx/html
+    build: .
     ports:
      - "8080:80"


### PR DESCRIPTION
# 👋👋👋

### - A complete Dockerfile for building bdunk.
The website was built using files generated by `bundle exec jekyll serve` command. This command puts dev mode and overrides `url` variable on _config.yml. That was why the published site was using this dev variable.

<img width="1552" alt="Captura de Pantalla 2022-08-01 a las 18 50 14" src="https://user-images.githubusercontent.com/28962947/182202213-d9d6f962-d6b5-4bf0-a851-7728d9587811.png">
<img width="1552" alt="Captura de Pantalla 2022-08-01 a las 18 49 41" src="https://user-images.githubusercontent.com/28962947/182202232-1e5db6af-b8cf-4e44-b606-6fdb45eda6b3.png">

### To avoid this, the website needs to be built using command `bundle exec jekyll build` as in Dockerfile.

